### PR TITLE
droid-hal: use sleep infinity in settingsd socket creation.

### DIFF
--- a/patches/frameworks/native/0006-hybris-Create-the-somehow-missing-settingsd-socket-f.patch
+++ b/patches/frameworks/native/0006-hybris-Create-the-somehow-missing-settingsd-socket-f.patch
@@ -1,28 +1,29 @@
-From 1700fefc6180c257f49f93cffd000b5a355126f5 Mon Sep 17 00:00:00 2001
+From 671d34023bd2ab7aab166d78155591d6084df151 Mon Sep 17 00:00:00 2001
 From: Franz-Josef Haider <franz.haider@jolla.com>
 Date: Sun, 16 Jun 2019 13:14:30 +0200
-Subject: [PATCH 6/6] (hybris) Create the (somehow) missing settingsd socket
+Subject: [PATCH 1/1] (hybris) Create the (somehow) missing settingsd socket
  for rild
 
 Change-Id: Ic7415aab65788f37ee5c5a67be1916319e484f77
 ---
- cmds/servicemanager/servicemanager.rc | 6 ++++++
- 1 file changed, 6 insertions(+)
+ cmds/servicemanager/servicemanager.rc | 7 +++++++
+ 1 file changed, 7 insertions(+)
 
 diff --git a/cmds/servicemanager/servicemanager.rc b/cmds/servicemanager/servicemanager.rc
-index b29934d..f137b67 100644
+index b29934d5a..bc2748bd8 100644
 --- a/cmds/servicemanager/servicemanager.rc
 +++ b/cmds/servicemanager/servicemanager.rc
-@@ -35,3 +35,9 @@ service miniaf /usr/libexec/droid-hybris/system/bin/miniafservice
+@@ -35,3 +35,10 @@ service miniaf /usr/libexec/droid-hybris/system/bin/miniafservice
      class main
      user system
      group audio
 +
 +# dummy service to create the (somehow) missing settingsd socket for rild
-+service settingsd_HYBRIS /system/bin/sleep 160
++service settingsd_HYBRIS /bin/sleep infinity
++    setenv LD_LIBRARY_PATH /usr/lib:/lib
 +    socket settingsd stream 0600 radio radio
 +    class early_hal
 +    oneshot
 -- 
-2.7.4
+2.17.1
 


### PR DESCRIPTION
[droid-hal] use sleep infinity in settingsd socket creation. JB#46145

Signed-off-by: Franz-Josef Haider <f_haider@gmx.at>