### PR TITLE
droid-hal: Use symlinks instead of moving sources around.

### DIFF
--- a/setup-sources.sh
+++ b/setup-sources.sh
@@ -4,8 +4,8 @@
 
 # move kernel subdirs into the right place
 rmdir kernel/sony/msm-4.9/kernel/drivers/staging/wlan-qc/fw-api
-mv fw-api kernel/sony/msm-4.9/kernel/drivers/staging/wlan-qc/fw-api
+ln -s ../../../../../../../fw-api kernel/sony/msm-4.9/kernel/drivers/staging/wlan-qc/fw-api
 rmdir kernel/sony/msm-4.9/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn
-mv qca-wifi-host-cmn kernel/sony/msm-4.9/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn
+ln -s ../../../../../../../qca-wifi-host-cmn kernel/sony/msm-4.9/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn
 rmdir kernel/sony/msm-4.9/kernel//drivers/staging/wlan-qc/qcacld-3.0
-mv qcacld-3.0 kernel/sony/msm-4.9/kernel/drivers/staging/wlan-qc/qcacld-3.0
+ln -s ../../../../../../../qcacld-3.0 kernel/sony/msm-4.9/kernel/drivers/staging/wlan-qc/qcacld-3.0


### PR DESCRIPTION
[droid-hal] Use symlinks instead of moving sources around. JB#46519